### PR TITLE
Trying to add NicknamesMatcher

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,31 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :phubme, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:phubme, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
-#
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+# config :phubme, 
+# HannahSlack: :HannahGithub

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-# config :phubme, 
-# HannahSlack: :HannahGithub
+# config :phubme,
+# "@Hannah": "@HannahSlack"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+# config :phubme, 
+# HannahSlack: :HannahGithub

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-# config :phubme, 
+# config :phubme,
 # HannahSlack: :HannahGithub

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,5 @@
 use Mix.Config
 
 config :phubme,
-'@Hannah': '@HannahSlack'
+"@Hannah": "@HannahSlack",
+"@lucie": "@lulu"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :phubme,
+'@Hannah': '@HannahSlack'

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -1,0 +1,31 @@
+defmodule PhubMe.NicknamesMatcher do
+  def match_nicknames({full_comment, github_nicknames, sender, comment_parsed}) do
+    # IO.inspect comment_parsed
+    {:ok, full_comment, matching_nicknames(github_nicknames, [], 0), sender, comment_parsed }
+  end
+
+  def match_nicknames(comment_parsed) do
+    # IO.inspect comment_parsed
+    {:no_nicknames_found}
+  end
+
+  defp matching_nicknames([github_nick_head | github_nick_tail], matched_nicknames, array_position) do
+    IO.inspect matched_nicknames
+    IO.puts nickname_from_mix_config(github_nick_head)
+    IO.inspect github_nick_head
+    matched_nicknames = List.insert_at(matched_nicknames, array_position, nickname_from_mix_config(github_nick_head))
+    matching_nicknames(github_nick_tail, matched_nicknames, array_position + 1)
+  end
+
+  defp matching_nicknames([], matched_nicknames, array_position) do
+    matched_nicknames
+  end
+
+  defp nickname_from_mix_config(github_nick_head) do
+    # IO.inspect Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head)))
+    case Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head))) do
+      {:ok, slack_nickname} -> slack_nickname
+      :error -> ""
+    end
+  end
+end

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -3,16 +3,20 @@ defmodule PhubMe.NicknamesMatcher do
     {:ok, full_comment, matching_nicknames(github_nicknames, [], 0), sender, comment_parsed }
   end
 
-  def match_nicknames(comment_parsed) do
+  def match_nicknames(_) do
     {:no_nicknames_found}
   end
 
-  defp matching_nicknames([h | t], matched_nicknames, array_position) do
-    matched_nicknames = List.insert_at(matched_nicknames, array_position, (h ++ nickname_from_mix_config(h)))
-    matching_nicknames(t, matched_nicknames, array_position + 1)
+  defp matching_nicknames([github_nick_head | github_nick_tail], matched_nicknames, array_position) do
+    if nickname_from_mix_config(github_nick_head) == :error do
+      IO.puts "No matching nickname found for " <> List.first(github_nick_head)
+    else
+      matched_nicknames = List.insert_at(matched_nicknames, array_position, (github_nick_head ++ nickname_from_mix_config(github_nick_head)))
+    end
+    matching_nicknames(github_nick_tail, matched_nicknames, array_position + 1)
   end
 
-  defp matching_nicknames([], matched_nicknames, array_position) do
+  defp matching_nicknames([], matched_nicknames, _) do
     matched_nicknames
   end
 
@@ -20,7 +24,7 @@ defmodule PhubMe.NicknamesMatcher do
     # IO.inspect Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head)))
     case Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head))) do
       {:ok, slack_nickname} -> [slack_nickname]
-      :error -> ""
+      :error -> :error
     end
   end
 end

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -1,20 +1,15 @@
 defmodule PhubMe.NicknamesMatcher do
   def match_nicknames({full_comment, github_nicknames, sender, comment_parsed}) do
-    # IO.inspect comment_parsed
     {:ok, full_comment, matching_nicknames(github_nicknames, [], 0), sender, comment_parsed }
   end
 
   def match_nicknames(comment_parsed) do
-    # IO.inspect comment_parsed
     {:no_nicknames_found}
   end
 
-  defp matching_nicknames([github_nick_head | github_nick_tail], matched_nicknames, array_position) do
-    IO.inspect matched_nicknames
-    IO.puts nickname_from_mix_config(github_nick_head)
-    IO.inspect github_nick_head
-    matched_nicknames = List.insert_at(matched_nicknames, array_position, nickname_from_mix_config(github_nick_head))
-    matching_nicknames(github_nick_tail, matched_nicknames, array_position + 1)
+  defp matching_nicknames([h | t], matched_nicknames, array_position) do
+    matched_nicknames = List.insert_at(matched_nicknames, array_position, (h ++ nickname_from_mix_config(h)))
+    matching_nicknames(t, matched_nicknames, array_position + 1)
   end
 
   defp matching_nicknames([], matched_nicknames, array_position) do
@@ -24,7 +19,7 @@ defmodule PhubMe.NicknamesMatcher do
   defp nickname_from_mix_config(github_nick_head) do
     # IO.inspect Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head)))
     case Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head))) do
-      {:ok, slack_nickname} -> slack_nickname
+      {:ok, slack_nickname} -> [slack_nickname]
       :error -> ""
     end
   end

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -8,12 +8,14 @@ defmodule PhubMe.NicknamesMatcher do
   end
 
   defp matching_nicknames([github_nick_head | github_nick_tail], matched_nicknames, array_position) do
-    if nickname_from_mix_config(github_nick_head) == :error do
-      IO.puts "No matching nickname found for " <> List.first(github_nick_head)
-    else
-      matched_nicknames = List.insert_at(matched_nicknames, array_position, (github_nick_head ++ nickname_from_mix_config(github_nick_head)))
-    end
-    matching_nicknames(github_nick_tail, matched_nicknames, array_position + 1)
+    updated_matched_nicknames =
+      if nickname_from_mix_config(github_nick_head) == :error do
+        IO.puts "No matching nickname found for " <> List.first(github_nick_head)
+        matched_nicknames
+      else
+        List.insert_at(matched_nicknames, array_position, (github_nick_head ++ nickname_from_mix_config(github_nick_head)))
+      end
+    matching_nicknames(github_nick_tail, updated_matched_nicknames, array_position + 1)
   end
 
   defp matching_nicknames([], matched_nicknames, _) do

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -21,7 +21,6 @@ defmodule PhubMe.NicknamesMatcher do
   end
 
   defp nickname_from_mix_config(github_nick_head) do
-    # IO.inspect Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head)))
     case Application.fetch_env(:phubme, String.to_atom(List.first(github_nick_head))) do
       {:ok, slack_nickname} -> [slack_nickname]
       :error -> :error

--- a/lib/phubme/web.ex
+++ b/lib/phubme/web.ex
@@ -21,6 +21,7 @@ defmodule PhubMe.Web do
     # How to test that it has been properly sent to ...
     # IO.inspect conn.body_params
     PhubMe.CommentParser.process_comment(conn.body_params)
+    |> PhubMe.NicknamesMatcher.match_nicknames
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(200, "ok")

--- a/test/fixtures/github_issue_comment_request.json
+++ b/test/fixtures/github_issue_comment_request.json
@@ -71,7 +71,7 @@
     },
     "created_at": "2015-05-05T23:40:28Z",
     "updated_at": "2015-05-05T23:40:28Z",
-    "body": "You are totally right! I'll get this fixed right away."
+    "body": "You are totally right! I'll get this fixed right away @Hannah."
   },
   "repository": {
     "id": 35129377,

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -1,0 +1,26 @@
+ExUnit.start
+
+defmodule NicknamesMatcher do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
+
+  defp comment_with_nicknames, do: "Hey @HannahArrendt you should take a look at @lucie"
+  defp tuples_with_matching_nicknames do
+    {comment_with_nicknames, [["@Hannah"], ["@lucie"]], "baxterthehacker", "https://github.com/comment"}
+  end
+
+  describe "PhubMe.NicknamesMatcher.match_nicknames/1" do
+    test "no tuples received" do
+      assert PhubMe.NicknamesMatcher.match_nicknames("stop here") ==  {:no_nicknames_found}
+    end
+
+    test "nicknames received with no matching nickname" do
+      assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_matching_nicknames) ==
+        {:ok, comment_with_nicknames, [['@Hannah', '@HannahSlack'], ['@lucie', '@lulu']], "baxterthehacker", "https://github.com/comment"}
+    end
+
+    test "nicknames received with matching nickname" do
+      #       PhubMe.NicknamesMatcher.match_nicknames(matching_nicknames) == answer_with_matching_nicknames
+    end
+  end
+end

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -8,6 +8,9 @@ defmodule NicknamesMatcher do
   defp tuples_with_matching_nicknames do
     {comment_with_nicknames, [["@Hannah"], ["@lucie"]], "baxterthehacker", "https://github.com/comment"}
   end
+  defp tuples_with_only_one_matching_nicknames do
+    {comment_with_nicknames, [["@Hannah"], ["@luie"]], "baxterthehacker", "https://github.com/comment"}
+  end
 
   describe "PhubMe.NicknamesMatcher.match_nicknames/1" do
     test "no tuples received" do
@@ -16,11 +19,12 @@ defmodule NicknamesMatcher do
 
     test "nicknames received with no matching nickname" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_matching_nicknames) ==
-        {:ok, comment_with_nicknames, [['@Hannah', '@HannahSlack'], ['@lucie', '@lulu']], "baxterthehacker", "https://github.com/comment"}
+        {:ok, comment_with_nicknames, [["@Hannah", "@HannahSlack"], ["@lucie", "@lulu"]], "baxterthehacker", "https://github.com/comment"}
     end
 
     test "nicknames received with matching nickname" do
-      #       PhubMe.NicknamesMatcher.match_nicknames(matching_nicknames) == answer_with_matching_nicknames
+      assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_only_one_matching_nicknames) ==
+        {:ok, comment_with_nicknames, [["@Hannah", "@HannahSlack"], ["@luie"]], "baxterthehacker", "https://github.com/comment"}
     end
   end
 end

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -2,7 +2,6 @@ ExUnit.start
 
 defmodule NicknamesMatcher do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   defp comment_with_nicknames, do: "Hey @HannahArrendt you should take a look at @lucie"
   defp tuples_with_matching_nicknames do
@@ -24,7 +23,7 @@ defmodule NicknamesMatcher do
 
     test "nicknames received with matching nickname" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_only_one_matching_nicknames) ==
-        {:ok, comment_with_nicknames, [["@Hannah", "@HannahSlack"], ["@luie"]], "baxterthehacker", "https://github.com/comment"}
+        {:ok, comment_with_nicknames, [["@Hannah", "@HannahSlack"]], "baxterthehacker", "https://github.com/comment"}
     end
   end
 end


### PR DESCRIPTION
Don't understand why it returns number... :/

```
     Assertion with == failed
     code: PhubMe.NicknamesMatcher.match_nicknames(tuples_with_matching_nicknames) == {:ok, comment_with_nicknames, [['@Hannah', '@HannahSlack'], ['@lucie', '@lulu']], "baxterthehacker", "https://github.com/comment"}
     lhs:  {:ok, "Hey @HannahArrendt you should take a look at @lucie", [[64, 72, 97, 110, 110, 97, 104, 83, 108, 97, 99, 107], ""], "baxterthehacker", "https://github.com/comment"}
     rhs:  {:ok, "Hey @HannahArrendt you should take a look at @lucie", [['@Hannah', '@HannahSlack'], ['@lucie', '@lulu']], "baxterthehacker", "https://github.com/comment"}
     stacktrace:
       test/lib/phubme/nicknames_matcher_test.exs:18: (test)
```
