### PR TITLE
Use an unique tuple when processing comments

### DIFF
--- a/lib/phubme/comment_parser.ex
+++ b/lib/phubme/comment_parser.ex
@@ -1,32 +1,15 @@
 defmodule PhubMe.CommentParser do
   def process_comment(body_params) do
     comment = get_in(body_params, ["comment", "body"])
-    sender  = get_in(body_params, ["comment", "user", "login"])
-    comment_source = get_in(body_params, ["comment", "html_url"])
-    IO.puts "Processing comment : \"" <> comment <> "\" from " <> sender
-    comment = comment
-              |> nicknames_present
-              |> extract_nicknames
-    case comment do
-      {:ok, full_comment, nicknames} -> {full_comment, nicknames, sender, comment_source}
-      {:error, _} -> "stop here"
-    end
+    sender = get_in(body_params, ["comment", "user", "login"])
+    source = get_in(body_params, ["comment", "html_url"])
+    nicknames = comment |> extract_nicknames
+    IO.puts "Processing comment : \"#{comment}\" from #{sender}"
+    {comment, nicknames, sender, source}
   end
 
-  defp nicknames_present(comment) do
-    if Regex.match?(~r{@([A-Za-z0-9_]+)}, comment) do
-      {:nicknames_found, comment}
-    else
-      {:no_nicknames_found, comment}
-    end
-  end
-
-  defp extract_nicknames({:nicknames_found, comment}) do
-    nicknames = Regex.scan ~r{@([A-Za-z0-9_]+)}, comment, capture: :first
-    {:ok, comment, nicknames}
-  end
-
-  defp extract_nicknames({:no_nicknames_found, _}) do
-    {:error, "No nicknames found in message"}
+  defp extract_nicknames(comment) do
+    matches = Regex.scan(~r{@([A-Za-z0-9_]+)}, comment, capture: :first)
+    matches |> List.flatten
   end
 end

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -1,15 +1,15 @@
 defmodule PhubMe.NicknamesMatcher do
+  def match_nicknames({_, [], _, _}) do
+    {:no_nicknames_found}
+  end
+
   def match_nicknames({full_comment, github_nicknames, sender, comment_parsed}) do
     {:ok, full_comment, matching_nicknames(github_nicknames), sender, comment_parsed }
   end
 
-  def match_nicknames(_) do
-    {:no_nicknames_found}
-  end
-
   defp matching_nicknames(list, acc \\ [])
 
-  defp matching_nicknames([ [ nickname ] | tail], acc) do
+  defp matching_nicknames([nickname | tail], acc) do
     next_acc =
       case nickname_from_mix_config(nickname) do
         {:ok, matching_nickname} -> [ [ nickname, matching_nickname ] | acc]

--- a/lib/phubme/web.ex
+++ b/lib/phubme/web.ex
@@ -20,8 +20,8 @@ defmodule PhubMe.Web do
     # IO.inspect conn.req_headers
     # How to test that it has been properly sent to ...
     # IO.inspect conn.body_params
-    PhubMe.CommentParser.process_comment(conn.body_params)
-    |> PhubMe.NicknamesMatcher.match_nicknames
+    parsed_comment = PhubMe.CommentParser.process_comment(conn.body_params)
+    IO.inspect parsed_comment
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(200, "ok")

--- a/test/lib/phubme/comment_parser_test.exs
+++ b/test/lib/phubme/comment_parser_test.exs
@@ -22,12 +22,12 @@ defmodule CommentParser do
 
     test "Parse message with two nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_with_nicknames)) ==
-        {comment_with_nicknames, [["@HannahArrendt"], ["@lucie"]], "baxterthehacker", "https://github.com/comment"}
+        {comment_with_nicknames, ["@HannahArrendt", "@lucie"], "baxterthehacker", "https://github.com/comment"}
     end
 
     test "Parse message with no nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_without_nickname)) ==
-        "stop here"
+        {comment_without_nickname, [], "baxterthehacker", "https://github.com/comment"}
     end
   end
 end

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -4,16 +4,20 @@ defmodule NicknamesMatcher do
   use ExUnit.Case, async: true
 
   defp comment_with_nicknames, do: "Hey @HannahArrendt you should take a look at @lucie"
+  defp comment_without_nickname, do: "Hello Hannah"
   defp tuples_with_matching_nicknames do
-    {comment_with_nicknames, [["@Hannah"], ["@lucie"]], "baxterthehacker", "https://github.com/comment"}
+    {comment_with_nicknames, ["@Hannah", "@lucie"], "baxterthehacker", "https://github.com/comment"}
   end
   defp tuples_with_no_matching_nicknames do
-    {comment_with_nicknames, [["@Hnnah"], ["@luie"]], "baxterthehacker", "https://github.com/comment"}
+    {comment_with_nicknames, ["@Hnnah", "@luie"], "baxterthehacker", "https://github.com/comment"}
+  end
+  defp tuples_with_no_nicknames do
+    {comment_without_nickname, [], "baxterthehacker", "https://github.com/comment"}
   end
 
   describe "PhubMe.NicknamesMatcher.match_nicknames/1" do
     test "no tuples received" do
-      assert PhubMe.NicknamesMatcher.match_nicknames("stop here") ==  {:no_nicknames_found}
+      assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_no_nicknames) ==  {:no_nicknames_found}
     end
 
     test "nicknames received with two matching nicknames" do


### PR DESCRIPTION
This refactoring is from the idea in #5 that the format of the list of nicknames was maybe too complex.

After digging into this, I noticed another thing in the `CommentParser`: `process_comment` would act differently depending on if there is mentions or not. This was IMO a source of unnecessary complexity. By using only one representation of a parsed comment, it makes it easier to compute and almost as easy to process (pattern-match) by the nickname matcher.
