### PR TITLE
Use structs for methods params

### DIFF
--- a/lib/phubme/comment_parser.ex
+++ b/lib/phubme/comment_parser.ex
@@ -8,8 +8,7 @@ defmodule PhubMe.CommentParser do
     source = get_in(body_params, ["comment", "html_url"])
     nicknames = comment |> extract_nicknames
     Logger.info("Processing comment : \"#{comment}\" from #{sender}")
-    {comment, nicknames, sender, source}
-    %Param{
+    %IssueComment{
       source: source,
       comment: comment,
       nicknames: nicknames,

--- a/lib/phubme/comment_parser.ex
+++ b/lib/phubme/comment_parser.ex
@@ -9,6 +9,12 @@ defmodule PhubMe.CommentParser do
     nicknames = comment |> extract_nicknames
     Logger.info("Processing comment : \"#{comment}\" from #{sender}")
     {comment, nicknames, sender, source}
+    %Param{
+      source: source,
+      comment: comment,
+      nicknames: nicknames,
+      sender: sender
+    }
   end
 
   defp extract_nicknames(nil) do

--- a/lib/phubme/issue_comment.ex
+++ b/lib/phubme/issue_comment.ex
@@ -1,3 +1,3 @@
-defmodule Param do
+defmodule IssueComment do
   defstruct [:comment, :nicknames, :sender, :source]
 end

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -1,18 +1,10 @@
 defmodule PhubMe.NicknamesMatcher do
-  def match_nicknames(%Param{nicknames: []}) do
+  def match_nicknames(%IssueComment{nicknames: []}) do
     {:error, "No nicknames found in this message"}
   end
 
-  def match_nicknames(%Param{comment: comment,
-                             nicknames: nicknames,
-                             sender: sender,
-                             source: source}) do
-    %Param{
-      comment: comment,
-      nicknames: matching_nicknames(nicknames),
-      sender: sender,
-      source: source
-    }
+  def match_nicknames(%IssueComment{nicknames: nicknames}=issue_comment) do
+    %{ issue_comment | nicknames: matching_nicknames(nicknames)}
   end
 
   defp matching_nicknames(list, acc \\ [])

--- a/lib/phubme/nicknames_matcher.ex
+++ b/lib/phubme/nicknames_matcher.ex
@@ -1,10 +1,18 @@
 defmodule PhubMe.NicknamesMatcher do
-  def match_nicknames({_, [], _, _}) do
+  def match_nicknames(%Param{nicknames: []}) do
     {:error, "No nicknames found in this message"}
   end
 
-  def match_nicknames({full_comment, github_nicknames, sender, comment_parsed}) do
-    {full_comment, matching_nicknames(github_nicknames), sender, comment_parsed }
+  def match_nicknames(%Param{comment: comment,
+                             nicknames: nicknames,
+                             sender: sender,
+                             source: source}) do
+    %Param{
+      comment: comment,
+      nicknames: matching_nicknames(nicknames),
+      sender: sender,
+      source: source
+    }
   end
 
   defp matching_nicknames(list, acc \\ [])

--- a/lib/phubme/param.ex
+++ b/lib/phubme/param.ex
@@ -1,0 +1,3 @@
+defmodule Param do
+  defstruct [:comment, :nicknames, :sender, :source]
+end

--- a/lib/phubme/slack.ex
+++ b/lib/phubme/slack.ex
@@ -5,25 +5,26 @@ defmodule PhubMe.Slack do
     Logger.error("[PhubMe][Error] " <> error_message)
   end
 
-  def send_private_message(%Param{nicknames: []}) do
+  def send_private_message(%IssueComment{nicknames: []}) do
     Logger.info("All procceed")
   end
 
-  def send_private_message(%Param{comment: comment,
+  def send_private_message(%IssueComment{comment: comment,
                                   nicknames: [nick_head | nick_tail],
-                                  sender: sender, source: source}) do
-    case Slack.Web.Chat.post_message(nick_head, formated_message(comment, sender, source), %{token: slack_token}) do
+                                  sender: sender, source: source}=issue_comment) do
+    case Slack.Web.Chat.post_message(nick_head, formated_message(issue_comment), %{token: slack_token}) do
       %{"error" => "invalid_auth"} -> invalid_slack_auth_message
       %{"ok" => false} -> no_matching_channel_message(nick_head)
       _ -> matching_channel_message
     end
 
-    send_private_message(%Param{comment: comment,
+    send_private_message(%IssueComment{comment: comment,
                                 nicknames: nick_tail,
-                                sender: sender, source: source})
+                                sender: sender,
+                                source: source})
   end
 
-  defp formated_message(comment, sender, source) do
+  defp formated_message(%IssueComment{comment: comment, sender: sender, source: source}) do
     "You've been mentionned on " <> source <> " from " <> sender <>
     ". Comment is : " <> comment
   end

--- a/lib/phubme/slack.ex
+++ b/lib/phubme/slack.ex
@@ -5,17 +5,22 @@ defmodule PhubMe.Slack do
     Logger.error("[PhubMe][Error] " <> error_message)
   end
 
-  def send_private_message({_comment, [], _sender, _source}) do
+  def send_private_message(%Param{nicknames: []}) do
     Logger.info("All procceed")
   end
 
-  def send_private_message({ comment, [nick_head | nick_tail], sender, source}) do
+  def send_private_message(%Param{comment: comment,
+                                  nicknames: [nick_head | nick_tail],
+                                  sender: sender, source: source}) do
     case Slack.Web.Chat.post_message(nick_head, formated_message(comment, sender, source), %{token: slack_token}) do
       %{"error" => "invalid_auth"} -> invalid_slack_auth_message
       %{"ok" => false} -> no_matching_channel_message(nick_head)
       _ -> matching_channel_message
     end
-    send_private_message({comment, nick_tail, sender, source})
+
+    send_private_message(%Param{comment: comment,
+                                nicknames: nick_tail,
+                                sender: sender, source: source})
   end
 
   defp formated_message(comment, sender, source) do

--- a/lib/phubme/slack.ex
+++ b/lib/phubme/slack.ex
@@ -24,7 +24,8 @@ defmodule PhubMe.Slack do
   end
 
   defp formated_message(comment, sender, source) do
-    "You've been mentionned on " <> source <> " from " <> sender <> ". Comment is : " <> comment
+    "You've been mentionned on " <> source <> " from " <> sender <>
+    ". Comment is : " <> comment
   end
 
   defp slack_token do
@@ -36,7 +37,8 @@ defmodule PhubMe.Slack do
   end
 
   defp no_matching_channel_message(nick) do
-    Logger.info("Not matching channel with the nickname " <> nick <> ". Are you sure it exists?")
+    Logger.info("Not matching channel with the nickname " <>
+                nick <> ". Are you sure it exists?")
   end
 
   defp matching_channel_message do

--- a/lib/phubme/slack.ex
+++ b/lib/phubme/slack.ex
@@ -9,19 +9,14 @@ defmodule PhubMe.Slack do
     Logger.info("All procceed")
   end
 
-  def send_private_message(%IssueComment{comment: comment,
-                                  nicknames: [nick_head | nick_tail],
-                                  sender: sender, source: source}=issue_comment) do
+  def send_private_message(%IssueComment{nicknames: [nick_head | nick_tail]}=issue_comment) do
     case Slack.Web.Chat.post_message(nick_head, formated_message(issue_comment), %{token: slack_token}) do
       %{"error" => "invalid_auth"} -> invalid_slack_auth_message
       %{"ok" => false} -> no_matching_channel_message(nick_head)
       _ -> matching_channel_message
     end
 
-    send_private_message(%IssueComment{comment: comment,
-                                nicknames: nick_tail,
-                                sender: sender,
-                                source: source})
+    send_private_message(%{ issue_comment | nicknames: nick_tail})
   end
 
   defp formated_message(%IssueComment{comment: comment, sender: sender, source: source}) do

--- a/lib/phubme/web.ex
+++ b/lib/phubme/web.ex
@@ -13,7 +13,9 @@ defmodule PhubMe.Web do
   end
 
   def start_link do
-    {:ok, _ } = Plug.Adapters.Cowboy.http PhubMe.Web, [], port: port(System.get_env("PORT"))
+    {:ok, _ } = Plug.Adapters.Cowboy.http(PhubMe.Web,
+                                          [],
+                                          port: port(System.get_env("PORT")))
   end
 
   def port(nil), do: 8080

--- a/test/lib/phubme/comment_parser_test.exs
+++ b/test/lib/phubme/comment_parser_test.exs
@@ -22,7 +22,7 @@ defmodule CommentParser do
 
     test "Parse message with two nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_with_nicknames)) ==
-        %Param{comment: "Hey @HannahArrendt you should take a look at @lucie",
+        %IssueComment{comment: "Hey @HannahArrendt you should take a look at @lucie",
                nicknames: ["@HannahArrendt", "@lucie"],
                sender: "baxterthehacker",
                source: "https://github.com/comment"}
@@ -30,7 +30,7 @@ defmodule CommentParser do
 
     test "Parse message with no nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_without_nickname)) ==
-        %Param{comment: "Hello Hannah", nicknames: [],
+        %IssueComment{comment: "Hello Hannah", nicknames: [],
             sender: "baxterthehacker", source: "https://github.com/comment"}
     end
 

--- a/test/lib/phubme/comment_parser_test.exs
+++ b/test/lib/phubme/comment_parser_test.exs
@@ -22,12 +22,16 @@ defmodule CommentParser do
 
     test "Parse message with two nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_with_nicknames)) ==
-        {comment_with_nicknames, ["@HannahArrendt", "@lucie"], "baxterthehacker", "https://github.com/comment"}
+        %Param{comment: "Hey @HannahArrendt you should take a look at @lucie",
+               nicknames: ["@HannahArrendt", "@lucie"],
+               sender: "baxterthehacker",
+               source: "https://github.com/comment"}
     end
 
     test "Parse message with no nicknames" do
       assert PhubMe.CommentParser.process_comment(body_params(comment_without_nickname)) ==
-        {comment_without_nickname, [], "baxterthehacker", "https://github.com/comment"}
+        %Param{comment: "Hello Hannah", nicknames: [],
+            sender: "baxterthehacker", source: "https://github.com/comment"}
     end
 
     test "Parse no github message" do

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -11,13 +11,13 @@ defmodule NicknamesMatcher do
   defp comment_with_nicknames, do: "Hey @HannahArrendt you should take a look at @lucie"
   defp comment_without_nickname, do: "Hello Hannah"
   defp tuples_with_matching_nicknames do
-    %Param{comment: comment_with_nicknames, nicknames: ["@hannah", "@lucie"], sender: "baxterthehacker", source: "https://github.com/comment"}
+    %IssueComment{comment: comment_with_nicknames, nicknames: ["@hannah", "@lucie"], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
   defp tuples_with_no_matching_nicknames do
-    %Param{comment: comment_with_nicknames, nicknames: ["@hnnah", "@luie"], sender: "baxterthehacker", source: "https://github.com/comment"}
+    %IssueComment{comment: comment_with_nicknames, nicknames: ["@hnnah", "@luie"], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
   defp tuples_with_no_nicknames do
-    %Param{comment: comment_without_nickname, nicknames: [], sender: "baxterthehacker", source: "https://github.com/comment"}
+    %IssueComment{comment: comment_without_nickname, nicknames: [], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
 
   describe "PhubMe.NicknamesMatcher.match_nicknames/1" do
@@ -27,7 +27,7 @@ defmodule NicknamesMatcher do
 
     test "nicknames received with two matching nicknames" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_matching_nicknames) ==
-        %Param{source: "https://github.com/comment",
+        %IssueComment{source: "https://github.com/comment",
           comment: "Hey @HannahArrendt you should take a look at @lucie",
           nicknames: ["@hannahslack", "@lulu"],
           sender: "baxterthehacker"}
@@ -35,7 +35,7 @@ defmodule NicknamesMatcher do
 
     test "nicknames received with no matching nickname" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_no_matching_nicknames) ==
-        %Param{source: "https://github.com/comment",
+        %IssueComment{source: "https://github.com/comment",
             comment: "Hey @HannahArrendt you should take a look at @lucie",
             nicknames: [], sender: "baxterthehacker"}
     end

--- a/test/lib/phubme/nicknames_matcher_test.exs
+++ b/test/lib/phubme/nicknames_matcher_test.exs
@@ -11,13 +11,13 @@ defmodule NicknamesMatcher do
   defp comment_with_nicknames, do: "Hey @HannahArrendt you should take a look at @lucie"
   defp comment_without_nickname, do: "Hello Hannah"
   defp tuples_with_matching_nicknames do
-    {comment_with_nicknames, ["@hannah", "@lucie"], "baxterthehacker", "https://github.com/comment"}
+    %Param{comment: comment_with_nicknames, nicknames: ["@hannah", "@lucie"], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
   defp tuples_with_no_matching_nicknames do
-    {comment_with_nicknames, ["@hnnah", "@luie"], "baxterthehacker", "https://github.com/comment"}
+    %Param{comment: comment_with_nicknames, nicknames: ["@hnnah", "@luie"], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
   defp tuples_with_no_nicknames do
-    {comment_without_nickname, [], "baxterthehacker", "https://github.com/comment"}
+    %Param{comment: comment_without_nickname, nicknames: [], sender: "baxterthehacker", source: "https://github.com/comment"}
   end
 
   describe "PhubMe.NicknamesMatcher.match_nicknames/1" do
@@ -27,12 +27,17 @@ defmodule NicknamesMatcher do
 
     test "nicknames received with two matching nicknames" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_matching_nicknames) ==
-        {comment_with_nicknames, ["@hannahslack", "@lulu"], "baxterthehacker", "https://github.com/comment"}
+        %Param{source: "https://github.com/comment",
+          comment: "Hey @HannahArrendt you should take a look at @lucie",
+          nicknames: ["@hannahslack", "@lulu"],
+          sender: "baxterthehacker"}
     end
 
     test "nicknames received with no matching nickname" do
       assert PhubMe.NicknamesMatcher.match_nicknames(tuples_with_no_matching_nicknames) ==
-        {comment_with_nicknames, [], "baxterthehacker", "https://github.com/comment"}
+        %Param{source: "https://github.com/comment",
+            comment: "Hey @HannahArrendt you should take a look at @lucie",
+            nicknames: [], sender: "baxterthehacker"}
     end
   end
 end

--- a/test/lib/phubme/slack_test.exs
+++ b/test/lib/phubme/slack_test.exs
@@ -7,19 +7,29 @@ defmodule PhubMeSlack do
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   defp full_params_with_one_nick do
-    {"comment_with_nicknames", ["@hanaack"], "baxterthehacker", "https://github.com/comment"}
+    %Param{source: "https://github.com/comment",
+      comment: "comment_with_nicknames",
+      nicknames: ["@hanaack"], sender: "baxterthehacker"}
   end
 
   defp full_params_without_nick do
-    {"comment_with_nicknames", [], "baxterthehacker", "https://github.com/comment"}
+    %Param{source: "https://github.com/comment",
+      comment: "Hey @HannahArrendt you should take a look at @lucie",
+      nicknames: [], sender: "baxterthehacker"}
   end
 
   defp full_params_with_nicks do
-    {"comment_with_nicknames", ["@hanaack", "@lulu"], "baxterthehacker", "https://github.com/comment"}
+    %Param{source: "https://github.com/comment",
+      comment: "full comment",
+      nicknames: ["@hannahslack", "@lulu"],
+      sender: "baxterthehacker"}
   end
 
   defp full_params_with_correct_nicks do
-    {"comment_with_nicknames", ["@hannahslack", "@benoit"], "baxterthehacker", "https://github.com/comment"}
+    %Param{source: "https://github.com/comment",
+      comment: "full comment",
+      nicknames: ["@hannahslack", "@benoit"],
+      sender: "baxterthehacker"}
   end
 
   defp incorrect_payload do

--- a/test/lib/phubme/slack_test.exs
+++ b/test/lib/phubme/slack_test.exs
@@ -7,26 +7,26 @@ defmodule PhubMeSlack do
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   defp full_params_with_one_nick do
-    %Param{source: "https://github.com/comment",
+    %IssueComment{source: "https://github.com/comment",
       comment: "comment_with_nicknames",
       nicknames: ["@hanaack"], sender: "baxterthehacker"}
   end
 
   defp full_params_without_nick do
-    %Param{source: "https://github.com/comment",
+    %IssueComment{source: "https://github.com/comment",
       comment: "Hey @HannahArrendt you should take a look at @lucie",
       nicknames: [], sender: "baxterthehacker"}
   end
 
   defp full_params_with_nicks do
-    %Param{source: "https://github.com/comment",
+    %IssueComment{source: "https://github.com/comment",
       comment: "full comment",
       nicknames: ["@hannahslack", "@lulu"],
       sender: "baxterthehacker"}
   end
 
   defp full_params_with_correct_nicks do
-    %Param{source: "https://github.com/comment",
+    %IssueComment{source: "https://github.com/comment",
       comment: "full comment",
       nicknames: ["@hannahslack", "@benoit"],
       sender: "baxterthehacker"}


### PR DESCRIPTION
Add more consistent param using struct. See : https://github.com/benoittgt/PhubMe/issues/12

Didn't used "string" as key as mention here : https://engineering.appcues.com/2016/02/02/too-many-dicts.html
Also didn't use a struct for errors param, kept a single tuple.
